### PR TITLE
Added PhantomJS installation path used in Travis CI.

### DIFF
--- a/browser-tests/browser/phantomjs.js
+++ b/browser-tests/browser/phantomjs.js
@@ -28,7 +28,7 @@ export default function startPhantom({
 
     if(!isWindows) {
       whichCommand = 'which' + ' phantomjs';
-      path = '/usr/local/bin:/usr/bin:/bin';
+      path = '/usr/local/bin:/usr/bin:/bin:/usr/local/phantomjs/bin';
       QtQPAPlatform = 'offscreen';
     }
     else {


### PR DESCRIPTION
Hello @ardatan,

on Travis CI there is a different installation path being used.

I added this path in this PR.

Thanks, Georgy