### PR TITLE
Allow overwriting Travis CI PhantomJS path with default system paths.

### DIFF
--- a/browser-tests/browser/phantomjs.js
+++ b/browser-tests/browser/phantomjs.js
@@ -29,7 +29,7 @@ export default function startPhantom({
 
     if(!isWindows) {
       whichCommand = 'which' + ' phantomjs';
-      path = '/usr/local/bin:/usr/bin:/bin:/usr/local/phantomjs/bin';
+      path = '/usr/local/phantomjs/bin:/usr/local/bin:/usr/bin:/bin';
       QtQPAPlatform = 'offscreen';
     }
     else {


### PR DESCRIPTION
Hello @ardatan,

this PR allows overwriting Travis CI PhantomJS path with default system paths.

Thanks, Georgy